### PR TITLE
chore: add vercel build env in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,18 @@ import react from "@vitejs/plugin-react"
 import fs from "fs"
 
 // https://vitejs.dev/config/
+
+const server =
+  process.env.DEPLOY_PLATFORM === "vite"
+    ? undefined
+    : {
+        https: {
+          key: fs.readFileSync("./localhost-key.pem"),
+          cert: fs.readFileSync("./localhost.pem"),
+        },
+      }
+
 export default defineConfig({
   plugins: [react()],
-  server: {
-    https: {
-      key: fs.readFileSync("./localhost-key.pem"),
-      cert: fs.readFileSync("./localhost.pem"),
-    },
-  },
+  server,
 })


### PR DESCRIPTION
pem should not use vercel

ignore server config in verce, to use environment variables on vercel config.